### PR TITLE
Include dist folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-src/dist
+src/dist/*
 babel/dist
 traceur/tmp
 


### PR DESCRIPTION
Currently src/dist is git ignored. If an individual attempts to run
`make babelify` on a fresh clone things will asplode due to the
directory not existing. This commit adds a empty hidden file to the
directory allowing it to be tracked by git.
