### PR TITLE
add rollup-plugin-babel-browserify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: babel typescript closure rollup traceur size rollup-plugin-babel webpack babelify
+.PHONY: babel typescript closure rollup traceur size rollup-plugin-babel rollup-plugin-babel-browserify webpack babelify
 
 all:
 	make typescript
@@ -8,6 +8,7 @@ all:
 	make babelify
 	make size
 	make rollup-plugin-babel
+	make rollup-plugin-babel-browserify
 	make size
 	make rollup
 	make size
@@ -32,6 +33,9 @@ rollup:
 
 rollup-plugin-babel:
 	cd rollup-plugin-babel; npm i; npm run compile
+
+rollup-plugin-babel-browserify:
+	cd rollup-plugin-babel-browserify; npm i; npm run compile
 
 closure:
 	cd closure; java -jar compiler.jar --language_in=ECMASCRIPT6_STRICT --js_output_file='../src/dist/bundle.js' '../src/src/**.js'

--- a/rollup-plugin-babel-browserify/npm-shrinkwrap.json
+++ b/rollup-plugin-babel-browserify/npm-shrinkwrap.json
@@ -1,0 +1,1320 @@
+{
+  "dependencies": {
+    "acorn": {
+      "version": "1.2.2",
+      "from": "acorn@>=1.0.3 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/acorn/-/acorn-1.2.2.tgz"
+    },
+    "align-text": {
+      "version": "0.1.3",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz"
+    },
+    "amdefine": {
+      "version": "1.0.0",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+    },
+    "ansi-regex": {
+      "version": "2.0.0",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.1.0",
+      "from": "ansi-styles@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+    },
+    "array-filter": {
+      "version": "0.0.1",
+      "from": "array-filter@>=0.0.0 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/array-filter/-/array-filter-0.0.1.tgz"
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "from": "array-map@>=0.0.0 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/array-map/-/array-map-0.0.0.tgz"
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "from": "array-reduce@>=0.0.0 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/array-reduce/-/array-reduce-0.0.0.tgz"
+    },
+    "asn1.js": {
+      "version": "4.3.1",
+      "from": "asn1.js@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/asn1.js/-/asn1.js-4.3.1.tgz"
+    },
+    "assert": {
+      "version": "1.3.0",
+      "from": "assert@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+    },
+    "astw": {
+      "version": "2.0.0",
+      "from": "astw@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/astw/-/astw-2.0.0.tgz"
+    },
+    "async": {
+      "version": "0.2.10",
+      "from": "async@>=0.2.6 <0.3.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+    },
+    "babel-code-frame": {
+      "version": "6.3.13",
+      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz"
+    },
+    "babel-core": {
+      "version": "6.4.5",
+      "from": "babel-core@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.4.5.tgz"
+    },
+    "babel-generator": {
+      "version": "6.4.5",
+      "from": "babel-generator@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.4.5.tgz"
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.3.13",
+      "from": "babel-helper-call-delegate@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.3.13.tgz"
+    },
+    "babel-helper-define-map": {
+      "version": "6.4.5",
+      "from": "babel-helper-define-map@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.4.5.tgz"
+    },
+    "babel-helper-function-name": {
+      "version": "6.4.0",
+      "from": "babel-helper-function-name@>=6.4.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.4.0.tgz"
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.3.13",
+      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.3.13",
+      "from": "babel-helper-hoist-variables@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.3.13.tgz"
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.3.13",
+      "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
+    },
+    "babel-helper-regex": {
+      "version": "6.3.13",
+      "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz"
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.3.13",
+      "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz"
+    },
+    "babel-helpers": {
+      "version": "6.4.5",
+      "from": "babel-helpers@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.4.5.tgz"
+    },
+    "babel-messages": {
+      "version": "6.3.18",
+      "from": "babel-messages@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.3.13",
+      "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.3.13.tgz"
+    },
+    "babel-plugin-external-helpers": {
+      "version": "6.4.0",
+      "from": "babel-plugin-external-helpers@>=6.0.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.4.0.tgz"
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.3.13",
+      "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.4.5",
+      "from": "babel-plugin-transform-es2015-classes@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.4.5.tgz"
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.4.5",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.4.5.tgz"
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.4.5",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.4.5.tgz"
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.4.0",
+      "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.4.0.tgz"
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-es2015-template-literals@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.3.13.tgz"
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.4.3",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.4.3.tgz"
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.4.3",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.4.3.tgz"
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.4.4",
+      "from": "babel-plugin-transform-regenerator@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.4.4.tgz"
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.3.13",
+      "from": "babel-plugin-transform-strict-mode@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.3.13.tgz"
+    },
+    "babel-preset-es2015": {
+      "version": "6.3.13",
+      "from": "babel-preset-es2015@>=6.0.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.3.13.tgz"
+    },
+    "babel-preset-es2015-rollup": {
+      "version": "1.1.1",
+      "from": "babel-preset-es2015-rollup@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-1.1.1.tgz"
+    },
+    "babel-register": {
+      "version": "6.4.3",
+      "from": "babel-register@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.4.3.tgz"
+    },
+    "babel-runtime": {
+      "version": "5.8.35",
+      "from": "babel-runtime@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
+    },
+    "babel-template": {
+      "version": "6.3.13",
+      "from": "babel-template@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz"
+    },
+    "babel-traverse": {
+      "version": "6.4.5",
+      "from": "babel-traverse@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.4.5.tgz"
+    },
+    "babel-types": {
+      "version": "6.4.5",
+      "from": "babel-types@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.4.5.tgz"
+    },
+    "babelify": {
+      "version": "7.2.0",
+      "from": "babelify@latest",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/babelify/-/babelify-7.2.0.tgz"
+    },
+    "babylon": {
+      "version": "6.4.5",
+      "from": "babylon@>=6.4.5 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.4.5.tgz"
+    },
+    "balanced-match": {
+      "version": "0.3.0",
+      "from": "balanced-match@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+    },
+    "base64-js": {
+      "version": "1.0.2",
+      "from": "base64-js@>=1.0.2 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/base64-js/-/base64-js-1.0.2.tgz"
+    },
+    "bn.js": {
+      "version": "4.10.0",
+      "from": "bn.js@>=4.1.1 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/bn.js/-/bn.js-4.10.0.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.2",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+    },
+    "brorand": {
+      "version": "1.0.5",
+      "from": "brorand@>=1.0.1 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/brorand/-/brorand-1.0.5.tgz"
+    },
+    "browser-pack": {
+      "version": "6.0.1",
+      "from": "browser-pack@>=6.0.1 <7.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browser-pack/-/browser-pack-6.0.1.tgz"
+    },
+    "browser-resolve": {
+      "version": "1.11.1",
+      "from": "browser-resolve@>=1.11.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browser-resolve/-/browser-resolve-1.11.1.tgz"
+    },
+    "browser-unpack": {
+      "version": "1.1.1",
+      "from": "browser-unpack@>=1.1.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browser-unpack/-/browser-unpack-1.1.1.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        },
+        "browser-pack": {
+          "version": "5.0.1",
+          "from": "browser-pack@5.0.1",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browser-pack/-/browser-pack-5.0.1.tgz"
+        },
+        "combine-source-map": {
+          "version": "0.6.1",
+          "from": "combine-source-map@0.6.1",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/combine-source-map/-/combine-source-map-0.6.1.tgz"
+        },
+        "inline-source-map": {
+          "version": "0.5.0",
+          "from": "inline-source-map@0.5.0",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/inline-source-map/-/inline-source-map-0.5.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "readable-stream@1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@1.1.1",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/through2/-/through2-1.1.1.tgz"
+        }
+      }
+    },
+    "browserify": {
+      "version": "13.0.0",
+      "from": "browserify@latest",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browserify/-/browserify-13.0.0.tgz"
+    },
+    "browserify-aes": {
+      "version": "1.0.6",
+      "from": "browserify-aes@>=1.0.4 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browserify-aes/-/browserify-aes-1.0.6.tgz"
+    },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "from": "browserify-cipher@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "from": "browserify-des@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browserify-des/-/browserify-des-1.0.0.tgz"
+    },
+    "browserify-rsa": {
+      "version": "4.0.0",
+      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+    },
+    "browserify-sign": {
+      "version": "4.0.0",
+      "from": "browserify-sign@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/browserify-sign/-/browserify-sign-4.0.0.tgz"
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "from": "browserify-zlib@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+    },
+    "buffer": {
+      "version": "4.4.0",
+      "from": "buffer@>=4.1.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/buffer/-/buffer-4.4.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        }
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "from": "buffer-xor@>=1.0.2 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/buffer-xor/-/buffer-xor-1.0.3.tgz"
+    },
+    "builtin-status-codes": {
+      "version": "1.0.0",
+      "from": "builtin-status-codes@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "from": "camelcase@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/center-align/-/center-align-0.1.3.tgz"
+    },
+    "chalk": {
+      "version": "1.1.1",
+      "from": "chalk@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+    },
+    "cipher-base": {
+      "version": "1.0.2",
+      "from": "cipher-base@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/cipher-base/-/cipher-base-1.0.2.tgz"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+    },
+    "combine-source-map": {
+      "version": "0.7.1",
+      "from": "combine-source-map@>=0.7.1 <0.8.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/combine-source-map/-/combine-source-map-0.7.1.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.2",
+          "from": "source-map@0.4.2",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/source-map/-/source-map-0.4.2.tgz"
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "concat-stream": {
+      "version": "1.5.1",
+      "from": "concat-stream@>=1.5.1 <1.6.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/concat-stream/-/concat-stream-1.5.1.tgz"
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "from": "console-browserify@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "from": "constants-browserify@>=1.0.0 <1.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/constants-browserify/-/constants-browserify-1.0.0.tgz"
+    },
+    "convert-source-map": {
+      "version": "1.1.3",
+      "from": "convert-source-map@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+    },
+    "core-js": {
+      "version": "1.2.6",
+      "from": "core-js@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "from": "create-ecdh@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/create-ecdh/-/create-ecdh-4.0.0.tgz"
+    },
+    "create-hash": {
+      "version": "1.1.2",
+      "from": "create-hash@>=1.1.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/create-hash/-/create-hash-1.1.2.tgz"
+    },
+    "create-hmac": {
+      "version": "1.1.4",
+      "from": "create-hmac@>=1.1.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/create-hmac/-/create-hmac-1.1.4.tgz"
+    },
+    "crypto-browserify": {
+      "version": "3.11.0",
+      "from": "crypto-browserify@>=3.0.0 <4.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "from": "date-now@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "from": "debug@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+    },
+    "decamelize": {
+      "version": "1.1.2",
+      "from": "decamelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
+    },
+    "defined": {
+      "version": "1.0.0",
+      "from": "defined@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/defined/-/defined-1.0.0.tgz"
+    },
+    "deps-sort": {
+      "version": "2.0.0",
+      "from": "deps-sort@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/deps-sort/-/deps-sort-2.0.0.tgz"
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "from": "des.js@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/des.js/-/des.js-1.0.0.tgz"
+    },
+    "detect-indent": {
+      "version": "3.0.1",
+      "from": "detect-indent@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
+    },
+    "detective": {
+      "version": "4.3.1",
+      "from": "detective@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/detective/-/detective-4.3.1.tgz"
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "from": "diffie-hellman@>=5.0.0 <6.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "from": "domain-browser@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "from": "duplexer2@>=0.1.2 <0.2.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/duplexer2/-/duplexer2-0.1.4.tgz"
+    },
+    "elliptic": {
+      "version": "6.2.3",
+      "from": "elliptic@>=6.0.0 <7.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/elliptic/-/elliptic-6.2.3.tgz"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.4",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+    },
+    "estree-walker": {
+      "version": "0.2.0",
+      "from": "estree-walker@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.0.tgz"
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "from": "esutils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+    },
+    "events": {
+      "version": "1.1.0",
+      "from": "events@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+    },
+    "evp_bytestokey": {
+      "version": "1.0.0",
+      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+    },
+    "extend": {
+      "version": "1.3.0",
+      "from": "extend@>=1.2.1 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/extend/-/extend-1.3.0.tgz"
+    },
+    "falafel": {
+      "version": "1.2.0",
+      "from": "falafel@>=1.2.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/falafel/-/falafel-1.2.0.tgz"
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "from": "foreach@>=2.0.5 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/foreach/-/foreach-2.0.5.tgz"
+    },
+    "function-bind": {
+      "version": "1.0.2",
+      "from": "function-bind@>=1.0.2 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/function-bind/-/function-bind-1.0.2.tgz"
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "glob": {
+      "version": "5.0.15",
+      "from": "glob@>=5.0.15 <6.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/glob/-/glob-5.0.15.tgz"
+    },
+    "globals": {
+      "version": "8.18.0",
+      "from": "globals@>=8.3.0 <9.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+    },
+    "has": {
+      "version": "1.0.1",
+      "from": "has@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/has/-/has-1.0.1.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "hash.js": {
+      "version": "1.0.3",
+      "from": "hash.js@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/hash.js/-/hash.js-1.0.3.tgz"
+    },
+    "home-or-tmp": {
+      "version": "1.0.0",
+      "from": "home-or-tmp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
+    },
+    "htmlescape": {
+      "version": "1.1.0",
+      "from": "htmlescape@>=1.1.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/htmlescape/-/htmlescape-1.1.0.tgz"
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "from": "https-browserify@>=0.0.0 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/https-browserify/-/https-browserify-0.0.1.tgz"
+    },
+    "ieee754": {
+      "version": "1.1.6",
+      "from": "ieee754@>=1.1.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "from": "indexof@0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+    },
+    "inflight": {
+      "version": "1.0.4",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/inflight/-/inflight-1.0.4.tgz"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "inline-source-map": {
+      "version": "0.6.1",
+      "from": "inline-source-map@>=0.6.0 <0.7.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/inline-source-map/-/inline-source-map-0.6.1.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
+    },
+    "insert-module-globals": {
+      "version": "7.0.1",
+      "from": "insert-module-globals@>=7.0.0 <8.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/insert-module-globals/-/insert-module-globals-7.0.1.tgz"
+    },
+    "invariant": {
+      "version": "2.2.0",
+      "from": "invariant@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
+    },
+    "is-buffer": {
+      "version": "1.1.2",
+      "from": "is-buffer@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+    },
+    "is-finite": {
+      "version": "1.0.1",
+      "from": "is-finite@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+    },
+    "is-integer": {
+      "version": "1.0.6",
+      "from": "is-integer@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "from": "isarray@0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "js-tokens": {
+      "version": "1.0.2",
+      "from": "js-tokens@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "from": "jsesc@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+    },
+    "json-stable-stringify": {
+      "version": "0.0.1",
+      "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz"
+    },
+    "json5": {
+      "version": "0.4.0",
+      "from": "json5@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/jsonify/-/jsonify-0.0.0.tgz"
+    },
+    "jsonparse": {
+      "version": "1.2.0",
+      "from": "jsonparse@>=1.1.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/jsonparse/-/jsonparse-1.2.0.tgz"
+    },
+    "JSONStream": {
+      "version": "1.0.7",
+      "from": "JSONStream@>=1.0.3 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/JSONStream/-/JSONStream-1.0.7.tgz"
+    },
+    "kind-of": {
+      "version": "2.0.1",
+      "from": "kind-of@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+    },
+    "labeled-stream-splicer": {
+      "version": "2.0.0",
+      "from": "labeled-stream-splicer@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz"
+    },
+    "lazy-cache": {
+      "version": "1.0.3",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/lazy-cache/-/lazy-cache-1.0.3.tgz"
+    },
+    "left-pad": {
+      "version": "0.0.3",
+      "from": "left-pad@0.0.3",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+    },
+    "lexical-scope": {
+      "version": "1.2.0",
+      "from": "lexical-scope@>=1.2.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/lexical-scope/-/lexical-scope-1.2.0.tgz"
+    },
+    "line-numbers": {
+      "version": "0.2.0",
+      "from": "line-numbers@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "from": "lodash@>=3.10.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+    },
+    "lodash.memoize": {
+      "version": "3.0.4",
+      "from": "lodash.memoize@>=3.0.3 <3.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+    },
+    "loose-envify": {
+      "version": "1.1.0",
+      "from": "loose-envify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "miller-rabin": {
+      "version": "4.0.0",
+      "from": "miller-rabin@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/miller-rabin/-/miller-rabin-4.0.0.tgz"
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "from": "minimatch@>=2.0.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "from": "minimist@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "module-deps": {
+      "version": "4.0.5",
+      "from": "module-deps@>=4.0.2 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/module-deps/-/module-deps-4.0.5.tgz"
+    },
+    "ms": {
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+    },
+    "number-is-nan": {
+      "version": "1.0.0",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+    },
+    "object-assign": {
+      "version": "4.0.1",
+      "from": "object-assign@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+    },
+    "object-keys": {
+      "version": "1.0.9",
+      "from": "object-keys@>=1.0.6 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/object-keys/-/object-keys-1.0.9.tgz"
+    },
+    "once": {
+      "version": "1.3.3",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/once/-/once-1.3.3.tgz"
+    },
+    "os-browserify": {
+      "version": "0.1.2",
+      "from": "os-browserify@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+    },
+    "os-tmpdir": {
+      "version": "1.0.1",
+      "from": "os-tmpdir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+    },
+    "pako": {
+      "version": "0.2.8",
+      "from": "pako@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+    },
+    "parents": {
+      "version": "1.0.1",
+      "from": "parents@>=1.0.1 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/parents/-/parents-1.0.1.tgz"
+    },
+    "parse-asn1": {
+      "version": "5.0.0",
+      "from": "parse-asn1@>=5.0.0 <6.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/parse-asn1/-/parse-asn1-5.0.0.tgz"
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "from": "path-browserify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+    },
+    "path-exists": {
+      "version": "1.0.0",
+      "from": "path-exists@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "from": "path-platform@>=0.11.15 <0.12.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/path-platform/-/path-platform-0.11.15.tgz"
+    },
+    "pbkdf2": {
+      "version": "3.0.4",
+      "from": "pbkdf2@>=3.0.3 <4.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/pbkdf2/-/pbkdf2-3.0.4.tgz"
+    },
+    "private": {
+      "version": "0.1.6",
+      "from": "private@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+    },
+    "process": {
+      "version": "0.11.2",
+      "from": "process@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+    },
+    "process-nextick-args": {
+      "version": "1.0.6",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+    },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "from": "public-encrypt@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/public-encrypt/-/public-encrypt-4.0.0.tgz"
+    },
+    "punycode": {
+      "version": "1.4.0",
+      "from": "punycode@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "from": "querystring-es3@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+    },
+    "randombytes": {
+      "version": "2.0.2",
+      "from": "randombytes@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/randombytes/-/randombytes-2.0.2.tgz"
+    },
+    "read-only-stream": {
+      "version": "2.0.0",
+      "from": "read-only-stream@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/read-only-stream/-/read-only-stream-2.0.0.tgz"
+    },
+    "readable-stream": {
+      "version": "2.0.5",
+      "from": "readable-stream@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+    },
+    "regenerate": {
+      "version": "1.2.1",
+      "from": "regenerate@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "from": "regexpu-core@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+    },
+    "repeat-string": {
+      "version": "1.5.2",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+    },
+    "repeating": {
+      "version": "1.1.3",
+      "from": "repeating@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "from": "require-relative@>=0.8.7 <0.9.0",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz"
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "from": "resolve@>=1.1.4 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/resolve/-/resolve-1.1.7.tgz"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+    },
+    "rimraf": {
+      "version": "2.5.1",
+      "from": "rimraf@>=2.5.1 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/rimraf/-/rimraf-2.5.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "from": "glob@>=6.0.1 <7.0.0",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/glob/-/glob-6.0.4.tgz"
+        }
+      }
+    },
+    "ripemd160": {
+      "version": "1.0.1",
+      "from": "ripemd160@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/ripemd160/-/ripemd160-1.0.1.tgz"
+    },
+    "rollup": {
+      "version": "0.25.2",
+      "from": "rollup@>=0.25.1 <0.26.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.25.2.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+        },
+        "source-map-support": {
+          "version": "0.3.3",
+          "from": "source-map-support@>=0.3.2 <0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz"
+        }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "2.3.9",
+      "from": "rollup-plugin-babel@>=2.3.9 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-2.3.9.tgz"
+    },
+    "rollup-pluginutils": {
+      "version": "1.3.1",
+      "from": "rollup-pluginutils@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.3.1.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+        }
+      }
+    },
+    "sha.js": {
+      "version": "2.4.4",
+      "from": "sha.js@>=2.3.6 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/sha.js/-/sha.js-2.4.4.tgz"
+    },
+    "shasum": {
+      "version": "1.0.2",
+      "from": "shasum@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/shasum/-/shasum-1.0.2.tgz"
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+    },
+    "shell-quote": {
+      "version": "1.4.3",
+      "from": "shell-quote@>=1.4.3 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/shell-quote/-/shell-quote-1.4.3.tgz"
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/sigmund/-/sigmund-1.0.1.tgz"
+    },
+    "slash": {
+      "version": "1.0.0",
+      "from": "slash@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+    },
+    "source-map": {
+      "version": "0.5.3",
+      "from": "source-map@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+    },
+    "source-map-support": {
+      "version": "0.2.10",
+      "from": "source-map-support@>=0.2.10 <0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
+        }
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "from": "stream-browserify@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/stream-browserify/-/stream-browserify-2.0.1.tgz"
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
+    },
+    "stream-http": {
+      "version": "2.1.0",
+      "from": "stream-http@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/stream-http/-/stream-http-2.1.0.tgz"
+    },
+    "stream-splicer": {
+      "version": "2.0.0",
+      "from": "stream-splicer@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/stream-splicer/-/stream-splicer-2.0.0.tgz"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.0",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+    },
+    "subarg": {
+      "version": "1.0.0",
+      "from": "subarg@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/subarg/-/subarg-1.0.0.tgz"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "syntax-error": {
+      "version": "1.1.5",
+      "from": "syntax-error@>=1.1.1 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/syntax-error/-/syntax-error-1.1.5.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.7.0 <3.0.0",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.2.7 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/through/-/through-2.3.8.tgz"
+    },
+    "through2": {
+      "version": "2.0.0",
+      "from": "through2@>=2.0.0 <3.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/through2/-/through2-2.0.0.tgz"
+    },
+    "timers-browserify": {
+      "version": "1.4.2",
+      "from": "timers-browserify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+    },
+    "to-fast-properties": {
+      "version": "1.0.1",
+      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "from": "trim-right@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "from": "tty-browserify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.5 <0.1.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+    },
+    "uglifyify": {
+      "version": "3.0.1",
+      "from": "uglifyify@latest",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/uglifyify/-/uglifyify-3.0.1.tgz",
+      "dependencies": {
+        "convert-source-map": {
+          "version": "0.2.6",
+          "from": "convert-source-map@>=0.2.3 <0.3.0",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/convert-source-map/-/convert-source-map-0.2.6.tgz"
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/minimatch/-/minimatch-0.3.0.tgz"
+        },
+        "uglify-js": {
+          "version": "2.6.1",
+          "from": "uglify-js@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz"
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "from": "yargs@>=3.10.0 <3.11.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        }
+      }
+    },
+    "uglifyjs": {
+      "version": "2.4.10",
+      "from": "uglifyjs@>=2.4.10 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglifyjs/-/uglifyjs-2.4.10.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.34",
+          "from": "source-map@0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz"
+        }
+      }
+    },
+    "umd": {
+      "version": "3.0.1",
+      "from": "umd@>=3.0.0 <4.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/umd/-/umd-3.0.1.tgz"
+    },
+    "url": {
+      "version": "0.11.0",
+      "from": "url@>=0.11.0 <0.12.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/url/-/url-0.11.0.tgz",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "from": "punycode@1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "from": "user-home@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+    },
+    "util": {
+      "version": "0.10.3",
+      "from": "util@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "from": "vm-browserify@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "from": "wordwrap@0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.1",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/wrappy/-/wrappy-1.0.1.tgz"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
+      "resolved": "http://nexus.nyc.squarespace.net:8081/nexus/content/groups/npm-all/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yargs": {
+      "version": "1.3.3",
+      "from": "yargs@>=1.3.3 <1.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+    }
+  }
+}

--- a/rollup-plugin-babel-browserify/package.json
+++ b/rollup-plugin-babel-browserify/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "compile": "rollup -c > tmp.js && browserify -t uglifyify tmp.js | uglifyjs --compress - > ../src/dist/bundle.js && rimraf tmp.js"
+  },
+  "dependencies": {
+    "babel-core": "^6.4.5",
+    "babel-preset-es2015-rollup": "^1.1.1",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
+    "rimraf": "^2.5.1",
+    "rollup": "^0.25.1",
+    "rollup-plugin-babel": "^2.3.9",
+    "uglifyify": "^3.0.1",
+    "uglifyjs": "^2.4.10"
+  }
+}

--- a/rollup-plugin-babel-browserify/rollup.config.js
+++ b/rollup-plugin-babel-browserify/rollup.config.js
@@ -1,0 +1,10 @@
+import babel from 'rollup-plugin-babel';
+import preset from 'babel-preset-es2015-rollup';
+
+export default {
+    entry: '../src/src/app.js',
+    plugins: [ babel({
+      presets: [ preset ]
+    }) ],
+    format: 'iife'
+};


### PR DESCRIPTION
Adds a new demo: `rollup-plugin-babel-browserify`, using Rollup+Babel as an input to Browserify, as well as the super-helpful kinda-obscure [uglifyify](https://github.com/hughsk/uglifyify) transform, which cuts down enormously on the bundle size as opposed to standard Browserify.

Using this toolchain, the bundle size is cut down to **3608**, which I believe is the smallest one yet in your sample. `uglifyify` is the big hero here; without it, we'd get 4343.

Love the demo, by the way! But I think one of the big takeaways is that it pays to really know your toolchain, as well as all the little tips and tricks to squeeze out bytes. :)
