### PR TITLE
use --mangle option with uglifyjs

### DIFF
--- a/babel/package.json
+++ b/babel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "babel ../src/src --presets ./node_modules/babel-preset-es2015 --out-dir=dist && browserify dist/app.js | ./node_modules/.bin/uglifyjs --compress - > ../src/dist/bundle.js"
+    "compile": "babel ../src/src --presets ./node_modules/babel-preset-es2015 --out-dir=dist && browserify dist/app.js | ./node_modules/.bin/uglifyjs --compress --mangle - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-cli": "^6.4.5",

--- a/babelify/package.json
+++ b/babelify/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "browserify ../src/src/app.js -t [ babelify --presets [ ./node_modules/babel-preset-es2015 ] ] | ./node_modules/.bin/uglifyjs --compress - > ../src/dist/bundle.js"
+    "compile": "browserify ../src/src/app.js -t [ babelify --presets [ ./node_modules/babel-preset-es2015 ] ] | ./node_modules/.bin/uglifyjs --compress --mangle - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-core": "^6.1.0",

--- a/rollup-plugin-babel/package.json
+++ b/rollup-plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "compile": "./node_modules/.bin/rollup -c | ./node_modules/.bin/uglifyjs --compress - > ../src/dist/bundle.js"
+    "compile": "./node_modules/.bin/rollup -c | ./node_modules/.bin/uglifyjs --compress --mangle - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-core": "^6.4.5",

--- a/rollup/package.json
+++ b/rollup/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "compile": "./node_modules/.bin/rollup --format iife -- ../src/src/app.js | ./node_modules/.bin/babel --presets ./node_modules/babel-preset-es2015/ | ./node_modules/.bin/uglifyjs --compress - > ../src/dist/bundle.js"
+    "compile": "./node_modules/.bin/rollup --format iife -- ../src/src/app.js | ./node_modules/.bin/babel --presets ./node_modules/babel-preset-es2015/ | ./node_modules/.bin/uglifyjs --compress --mangle - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-cli": "^6.4.5",

--- a/traceur/package.json
+++ b/traceur/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "compile": "npm run traceur && npm run browserify",
     "traceur": "traceur --modules=commonjs --dir ../src/src/ tmp/",
-    "browserify": "(cat node_modules/traceur/bin/traceur-runtime.js; browserify tmp/app.js;) | ./node_modules/.bin/uglifyjs --compress - > ../src/dist/bundle.js"
+    "browserify": "(cat node_modules/traceur/bin/traceur-runtime.js; browserify tmp/app.js;) | ./node_modules/.bin/uglifyjs --compress --mangle - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "browserify": "^13.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "compile": "(cat almond.js; ./node_modules/.bin/tsc --allowJs --module amd --outFile /dev/stdout ../src/src/app.js; cat bootstrap.js) | ./node_modules/.bin/uglifyjs --compress - > ../src/dist/bundle.js"
+    "compile": "(cat almond.js; ./node_modules/.bin/tsc --allowJs --module amd --outFile /dev/stdout ../src/src/app.js; cat bootstrap.js) | ./node_modules/.bin/uglifyjs --compress --mangle - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "typescript": "^1.8.0",


### PR DESCRIPTION
Thanks for doing this awesome research!

I was surprised to see Webpack beating Rollup, so I poked around a bit – it seems that while the Webpack example is using `UglifyJsPlugin`, which mangles variable names, the `npm run compile` scripts don't use the `--mangle` option.

With `--mangle`, I get different results for `make size`:

| example | without mangle | with mangle | gzip without mangle | gzip with mangle |
| --- | --- | --- | --- | --- |
| babel | 20366 | 14328 | 4770 | **3884** |
| babelify | 20366 | 14328 | 4770 | **3884** |
| rollup | 15213 | 11281 | 4175 | **3398** |
| rollup-plugin-babel | 15365 | 11308 | 4130 | **3407** |
| traceur | 98117 | 68879 | 22357 | **18112** |
| typescript | 19455 | 13811 | 5379 | **4424** |

So Rollup now beats Webpack (3737).

Obviously this is just sour grapes on my part (I created Rollup) but I do think it's a fairer comparison :grinning: 
