### PR TITLE
Unmangle webpack

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -16,6 +16,6 @@ module.exports = {
   },
   resolveLoader: { root: path.join(__dirname, 'node_modules') },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin()
+    new webpack.optimize.UglifyJsPlugin({ mangle: false })
   ]
 };


### PR DESCRIPTION
An alternate to #17. I didn't realize webpack's plugin was mangling by default, but it seems just as reasonable to not mangle everywhere as is it to mangle everywhere.  This won't change per library right?
