### PR TITLE
added typescript + webpack

### DIFF
--- a/typescript-webpack/.gitignore
+++ b/typescript-webpack/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/typescript-webpack/npm-shrinkwrap.json
+++ b/typescript-webpack/npm-shrinkwrap.json
@@ -1,0 +1,922 @@
+{
+  "dependencies": {
+    "typescript": {
+      "version": "1.8.0",
+      "from": "typescript@>=1.8.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.0.tgz"
+    },
+    "uglifyjs": {
+      "version": "2.4.10",
+      "from": "uglifyjs@>=2.4.10 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglifyjs/-/uglifyjs-2.4.10.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "source-map": {
+          "version": "0.1.34",
+          "from": "source-map@0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            }
+          }
+        },
+        "yargs": {
+          "version": "1.3.3",
+          "from": "yargs@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+        }
+      }
+    },
+    "webpack": {
+      "version": "1.12.12",
+      "from": "webpack@>=1.12.12 <2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.12.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "clone@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "memory-fs@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.3",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.2",
+          "from": "esprima@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@>=0.6.4 <0.7.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.12",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "from": "memory-fs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "errno@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.0.5",
+              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.5.3",
+          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+          "dependencies": {
+            "assert": {
+              "version": "1.3.0",
+              "from": "assert@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.8",
+                  "from": "pako@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "3.6.0",
+              "from": "buffer@>=3.0.3 <4.0.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.8",
+                  "from": "base64-js@0.0.8",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.6",
+                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1",
+              "from": "constants-browserify@0.0.1",
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+            },
+            "crypto-browserify": {
+              "version": "3.2.8",
+              "from": "crypto-browserify@>=3.2.6 <3.3.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1",
+                  "from": "pbkdf2-compat@2.0.1",
+                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "from": "ripemd160@0.2.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.2.6",
+                  "from": "sha.js@2.2.6",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.7",
+              "from": "domain-browser@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+            },
+            "events": {
+              "version": "1.1.0",
+              "from": "events@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "from": "http-browserify@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1",
+                  "from": "Base64@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0",
+              "from": "https-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+            },
+            "os-browserify": {
+              "version": "0.1.2",
+              "from": "os-browserify@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "path-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.11.2",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+            },
+            "punycode": {
+              "version": "1.4.0",
+              "from": "punycode@>=1.2.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.25 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "timers-browserify": {
+              "version": "1.4.2",
+              "from": "timers-browserify@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "tty-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.10.3",
+              "from": "url@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@1.3.2",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "util@>=0.10.3 <0.11.0",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "vm-browserify@0.0.4",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "from": "tapable@>=0.1.8 <0.2.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+        },
+        "uglify-js": {
+          "version": "2.6.1",
+          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.3",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.0.2",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.2",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "1.0.3",
+                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "from": "align-text@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.0.2",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.2",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.1.2",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    }
+                  }
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "from": "watchpack@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "chokidar": {
+              "version": "1.4.2",
+              "from": "chokidar@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                    },
+                    "micromatch": {
+                      "version": "2.3.7",
+                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.0.1",
+                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                        },
+                        "braces": {
+                          "version": "1.8.3",
+                          "from": "braces@>=1.8.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.1",
+                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "2.0.0",
+                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.5",
+                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.4",
+                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                        },
+                        "extglob": {
+                          "version": "0.3.2",
+                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "3.0.2",
+                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.2",
+                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.0.1",
+                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                        },
+                        "object.omit": {
+                          "version": "2.0.0",
+                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.2",
+                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.2",
+                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.4.0",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "readdirp": {
+                  "version": "2.0.0",
+                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.2",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.3",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.5",
+              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/typescript-webpack/package.json
+++ b/typescript-webpack/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "compile": "tsc && webpack ./dist/app.js ../src/dist/app.js -p"
+  },
+  "dependencies": {
+    "typescript": "^1.8.0",
+    "uglifyjs": "^2.4.10",
+    "webpack": "^1.12.12"
+  }
+}

--- a/typescript-webpack/tsconfig.json
+++ b/typescript-webpack/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "module": "commonjs",
+        "outDir": "./dist",
+        "target": "es5",
+        "noImplicitAny": false,
+        "sourceMap": false
+    },
+    "files": [
+        "../src/src/app.js",
+        "../src/src/controller.js",
+        "../src/src/helpers.js",
+        "../src/src/model.js",
+        "../src/src/store.js",
+        "../src/src/template.js",
+        "../src/src/view.js"
+    ]
+}


### PR DESCRIPTION
The `typescript + uglifyjs` is actually `typescript + browserify + uglifyjs`.

Therefore you also have the choice to use `typescript + webpack + uglifyjs` which gave me this numbers:

| Tools | File Size (bytes) | gzip size (bytes) | js execution time (ms) | js compile time (ms) | tool run time (s) |
| --- | --- | --- | --- | --- | --- |
| closure | 7847 | 2890 | 53.15 | 9.56 | 7.938 |
| **typescript + webpack + uglify** | **11128** | **3164** | ? | ? | ? |
| typescript + browserify + uglify | 11442 | 3385 | 48.49 | 8.61 | 3.166 |
| babel + rollup + uglify | 11439 | 3456 | 50.81 | 7.26 | 4.233 |

Please calculate the numbers by yourself, as I'm using windows and this sometimes give different results.

PS: The folder `typescript` should propably renamed to `typescript-browserify`, but that's up to you.
