### PR TITLE
Add brotli compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,5 @@ size:
 	@echo -----------------------------------------
 	stat -f%z src/dist/bundle.js
 	gzip -c src/dist/bundle.js | wc -c
+	bro --input src/dist/bundle.js | wc -c
 	@echo -----------------------------------------

--- a/README.md
+++ b/README.md
@@ -72,18 +72,18 @@ Ignoring the outlier of traceur, people should heavily consider using a tool tha
 ##### Raw data
 
 
-| Tools                            | File Size (bytes) | gzip size (bytes) | js execution time (ms) | js compile time (ms) |tool run time (s)|
-| ---------------------------------|-------------------|-------------------|------------------------|----------------------|-----------------|
-| closure                          | 7847              | 2890              | 53.15                  | 9.56                 |7.938            |
-| babel + rollup + uglify          | 11439             | 3456              | 50.81                  | 7.26                 |4.233            |
-| typescript + browserify + uglify | 11442             | 3385              | 48.49                  | 8.61                 |3.166            |
-| rollup-plugin-babel + uglify     | 11466             | 3466              | 49.50                  | 7.85                 |2.754            |
-| webpack@2 + babel + uglify       | 13252             | 3572              | 51.28                  | 8.35                 |8.587            |
-| webpack + babel + uglify         | 13973             | 3737              | 51.28                  | 9.59                 |6.228            |
-| babel + browserify + uglify      | 14328             | 3884              | 53.37                  | 8.85                 |4.947            |
-| babelify + uglify                | 14486             | 3942              | 43.96                  | 8.25                 |3.511            |
-| jspm                             | 15151             | 4602              | 55.46                  | 8.05                 |9.579            |
-| traceur + browserify + uglify    | 69037             | 18166             | 66.60                  | 7.95                 |7.271            |
+| Tools                            | File Size (bytes) | gzip size (bytes) | brotli size (bytes) | js execution time (ms) | js compile time (ms) | tool run time (s) |
+| ---------------------------------|-------------------|-------------------|---------------------|------------------------|----------------------|-------------------|
+| closure                          | 7847              | 2890              | 2529                | 53.15                  | 9.56                 | 7.938             |
+| babel + rollup + uglify          | 11439             | 3456              | 2996                | 50.81                  | 7.26                 | 4.233             |
+| rollup-plugin-babel + uglify     | 11466             | 3466              | 3010                | 49.50                  | 7.85                 | 2.754             |
+| typescript + browserify + uglify | 11600             | 3439              | 3007                | 48.49                  | 8.61                 | 3.166             |
+| webpack@2 + babel + uglify       | 13410             | 3629              | 3148                | 51.28                  | 8.35                 | 8.587             |
+| webpack + babel + uglify         | 14130             | 3796              | 3307                | 51.28                  | 9.59                 | 6.228             |
+| babel + browserify + uglify      | 14486             | 3942              | 3439                | 53.37                  | 8.85                 | 4.947             |
+| babelify + uglify                | 14486             | 3942              | 3439                | 43.96                  | 8.25                 | 3.511             |
+| jspm                             | 15151             | 4602              | 4048                | 55.46                  | 8.05                 | 9.579             |
+| traceur + browserify + uglify    | 69037             | 18166             | 16104               | 66.60                  | 7.95                 | 7.271             |
 
 --------------------------------
 


### PR DESCRIPTION
Anyone obsessed with saving bytes should be curious to know what brotli can offer, so I added it to the size task using brotli 0.3.0 installed via Homebrew.
Brotli-compressed files can already be served to Firefox. Support in Chrome stable will come soon enough.

Some of the results differ from yours on my machine for some reason, I decided to include them anyway.

`make babel` and `make babelify` gave the exact same file size, I haven't looked deep into it.
