### PR TITLE
Update jspm case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/dist/*
 babel/dist
 typescript/dist
 traceur/tmp
+jspm/jspm_packages
 
 .DS_Store
 

--- a/jspm/jspm.browser.js
+++ b/jspm/jspm.browser.js
@@ -1,0 +1,5 @@
+SystemJS.config({
+  paths: {
+    "npm:*": "/jspm_packages/npm/*"
+  }
+});

--- a/jspm/jspm.config.js
+++ b/jspm/jspm.config.js
@@ -3,16 +3,16 @@ SystemJS.config({
     "npm:@*/*.json",
     "npm:*.json"
   ],
-  globalEvaluationScope: false,
   transpiler: "plugin-babel",
   sourceMaps: false,
+
   map: {
     "plugin-babel": "npm:systemjs-plugin-babel@0.0.2"
   },
 
   packages: {
     "src": {
-      defaultExtension: "js"
+      "defaultExtension": "js"
     }
   }
 });

--- a/jspm/package.json
+++ b/jspm/package.json
@@ -1,10 +1,10 @@
 {
   "scripts": {
     "postinstall": "./node_modules/.bin/jspm install",
-    "compile": "./node_modules/.bin/jspm build src/app.js ../src/dist/bundle.js --minify --skip-source-maps --format global "
+    "compile": "./node_modules/.bin/jspm build src/app.js ../src/dist/bundle.js --skip-source-maps --minify --format global --global-name app"
   },
   "dependencies": {
-    "jspm": "^0.17.0-beta.5"
+    "jspm": "^0.17.0-beta.6"
   },
   "jspm": {
     "name": "app",


### PR DESCRIPTION
Rollup requires the global name to be set in order to work, the latest beta at least throws a proper error message here isn't of just silently letting the rollup optimization fail.

Should get a much better score now, although it is somewhat cheating as it is all thanks to Rollup anyway :)
