### PR TITLE
Add --screw-ie8 to uglifyjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ Ignoring the outlier of traceur, people should heavily consider using a tool tha
 | closure                               | 7847              | 2890              | 2529                | 53.15                  | 9.56                 | 7.938             |
 | jspm@0.17 (babel + rollup + uglify)   | 11049             | 3393              | 2935                | 55.46                  | 8.05                 | 2.978             |
 | typescript + webpack                  | 11128             | 3245              | 2827                | 56.57                  | 8.45                 | 4.636             |
-| babel + rollup + uglify               | 11441             | 3456              | 2997                | 50.81                  | 7.26                 | 2.396             |
-| rollup-plugin-babel + uglify          | 11468             | 3466              | 3014                | 49.50                  | 7.85                 | 2.806             |
-| typescript + browserify + uglify      | 11472             | 3418              | 2981                | 48.49                  | 8.61                 | 2.724             |
+| babel + rollup + uglify               | 11423             | 3440              | 2989                | 50.81                  | 7.26                 | 2.396             |
+| typescript + browserify + uglify      | 11442             | 3415              | 2976                | 48.49                  | 8.61                 | 2.724             |
+| rollup-plugin-babel + uglify          | 11444             | 3447              | 2997                | 49.50                  | 7.85                 | 2.806             |
 | webpack@2 + babel + uglify            | 13346             | 3632              | 3157                | 51.28                  | 8.35                 | 2.007             |
 | webpack + babel + uglify              | 14130             | 3796              | 3307                | 51.28                  | 9.59                 | 2.045             |
-| babel + browserify + uglify           | 14462             | 3931              | 3433                | 53.37                  | 8.85                 | 4.947             |
-| babelify + uglify                     | 14462             | 3931              | 3433                | 43.96                  | 8.25                 | 3.697             |
-| traceur + browserify + uglify         | 68920             | 18162             | 16078               | 66.60                  | 7.95                 | 3.085             |
+| babel + browserify + uglify           | 14409             | 3915              | 3422                | 53.37                  | 8.85                 | 4.947             |
+| babelify + uglify                     | 14409             | 3915              | 3422                | 43.96                  | 8.25                 | 3.697             |
+| traceur + browserify + uglify         | 68699             | 18000             | 15945               | 66.60                  | 7.95                 | 3.085             |
 
 -------------------------------------
 

--- a/babel/package.json
+++ b/babel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "babel ../src/src --presets ./node_modules/babel-preset-es2015 --out-dir dist && browserify -p bundle-collapser/plugin dist/app.js | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
+    "compile": "babel ../src/src --presets ./node_modules/babel-preset-es2015 --out-dir dist && browserify -p bundle-collapser/plugin dist/app.js | uglifyjs --compress --mangle --screw-ie8 - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-cli": "^6.4.5",

--- a/babelify/package.json
+++ b/babelify/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "browserify ../src/src/app.js -t [ babelify --presets [ ./node_modules/babel-preset-es2015 ] ] -p bundle-collapser/plugin | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
+    "compile": "browserify ../src/src/app.js -t [ babelify --presets [ ./node_modules/babel-preset-es2015 ] ] -p bundle-collapser/plugin | uglifyjs --compress --mangle --screw-ie8 - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",

--- a/rollup-plugin-babel/package.json
+++ b/rollup-plugin-babel/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "rollup -c | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
+    "compile": "rollup -c | uglifyjs --compress --mangle --screw-ie8 - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-preset-es2015-rollup": "^1.1.1",

--- a/rollup/package.json
+++ b/rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "rollup --format iife -- ../src/src/app.js | babel --presets ./node_modules/babel-preset-es2015 | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
+    "compile": "rollup --format iife -- ../src/src/app.js | babel --presets ./node_modules/babel-preset-es2015 | uglifyjs --compress --mangle --screw-ie8 - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "babel-cli": "^6.4.5",

--- a/traceur/package.json
+++ b/traceur/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "compile": "npm run traceur && npm run browserify",
     "traceur": "traceur --modules=commonjs --dir ../src/src/ tmp/",
-    "browserify": "(cat node_modules/traceur/bin/traceur-runtime.js; browserify -p bundle-collapser/plugin tmp/app.js;) | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
+    "browserify": "(cat node_modules/traceur/bin/traceur-runtime.js; browserify -p bundle-collapser/plugin tmp/app.js;) | uglifyjs --compress --mangle --screw-ie8 - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "browserify": "^13.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "compile": "tsc && browserify -p bundle-collapser/plugin ./dist/*.js | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
+    "compile": "tsc && browserify -p bundle-collapser/plugin ./dist/*.js | uglifyjs --compress --mangle --screw-ie8 - > ../src/dist/bundle.js"
   },
   "dependencies": {
     "browserify": "^13.0.0",


### PR DESCRIPTION
I'm sure this is appropriate for _most_ projects.

Plot twist: --screw-ie8 made typescript go up a rank in file size! Coincidence?
