### PR TITLE
Move compile commands into the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 .PHONY: babel typescript closure rollup traceur size rollup-plugin-babel webpack babelify jspm webpack-2 typescript-webpack
 
+# local binary paths
+browserify = node ./node_modules/browserify/bin/cmd.js
+uglifyjs = node ./node_modules/uglify-js/bin/uglifyjs
+babel = node ./node_modules/babel-cli/bin/babel.js
+traceur = node node_modules/traceur/bin/traceur.js
+tsc = node node_modules/typescript/bin/tsc
+rollup = node node_modules/rollup/bin/rollup
+jspm = node node_modules/jspm/jspm.js
+webpack = node node_modules/webpack/bin/webpack.js
+
 all:
 	make typescript
 	make size
@@ -25,41 +35,51 @@ all:
 	make size
 
 typescript:
-	cd typescript; npm i; time npm run compile;
+	cd typescript; npm i;
+	cd typescript; time $(tsc) && $(browserify) -p bundle-collapser/plugin ./dist/*.js | $(uglifyjs) --compress --mangle - > ../src/dist/bundle.js
 
 babel:
-	cd babel; npm i; time npm run compile
+	cd babel; npm i;
+	cd babel; time $(babel) ../src/src --presets ./node_modules/babel-preset-es2015 --out-dir dist && $(browserify) -p bundle-collapser/plugin dist/app.js | $(uglifyjs) --compress --mangle - > ../src/dist/bundle.js
 
 babelify:
-	cd babelify; npm i; time npm run compile
+	cd babelify; npm i;
+	cd babelify; time $(browserify) ../src/src/app.js -t [ babelify --presets [ ./node_modules/babel-preset-es2015 ] ] -p bundle-collapser/plugin | $(uglifyjs) --compress --mangle - > ../src/dist/bundle.js
 
 rollup:
-	cd rollup; npm i; time npm run compile
+	cd rollup; npm i;
+	cd rollup; time $(rollup) --format iife -- ../src/src/app.js | $(babel) --presets ./node_modules/babel-preset-es2015 | $(uglifyjs) --compress --mangle - > ../src/dist/bundle.js
 
 rollup-plugin-babel:
-	cd rollup-plugin-babel; npm i; time npm run compile
+	cd rollup-plugin-babel; npm i;
+	cd rollup-plugin-babel; time $(rollup) -c | $(uglifyjs) --compress --mangle - > ../src/dist/bundle.js
 
 closure:
 	cd closure; time java -jar compiler.jar --compilation_level ADVANCED_OPTIMIZATIONS --language_in=ECMASCRIPT6_STRICT --js_output_file='../src/dist/bundle.js' '../src/src/**.js'
 
 traceur:
-	cd traceur; npm i; time npm run compile
+	cd traceur; npm i;
+	cd traceur; time $(traceur) --modules=commonjs --dir ../src/src/ tmp/ && (cat node_modules/traceur/bin/traceur-runtime.js; $(browserify) -p bundle-collapser/plugin tmp/app.js;) | $(uglifyjs) --compress --mangle - > ../src/dist/bundle.js
 
 webpack:
-	cd webpack; npm i; time npm run compile
+	cd webpack; npm i;
+	cd webpack; time $(webpack) ../src/src/app.js ../src/dist/bundle.js
 
 jspm:
-	cd jspm; npm i; time npm run compile
+	cd jspm; npm i;
+	cd jspm; time $(jspm) build src/app.js ../src/dist/bundle.js --skip-source-maps --minify --format global --global-name app
 
 webpack-2:
-	cd webpack-2; npm i; time npm run compile
+	cd webpack-2; npm i;
+	cd webpack-2; time $(webpack) ../src/src/app.js ../src/dist/bundle.js
 
 typescript-webpack:
-	cd typescript-webpack; npm i; time npm run compile
+	cd typescript-webpack; npm i;
+	cd typescript-webpack; time $(tsc) && $(webpack) ./dist/app.js ../src/dist/bundle.js -p
 
 size:
 	@echo -----------------------------------------
-	stat -f%z src/dist/bundle.js
+	cat src/dist/bundle.js | wc -c
 	gzip -c src/dist/bundle.js | wc -c
 	bro --input src/dist/bundle.js | wc -c
 	@echo -----------------------------------------

--- a/babel/package.json
+++ b/babel/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "babel ../src/src --presets ./node_modules/babel-preset-es2015 --out-dir dist && browserify -p bundle-collapser/plugin dist/app.js | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
-  },
   "dependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",

--- a/babelify/package.json
+++ b/babelify/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "browserify ../src/src/app.js -t [ babelify --presets [ ./node_modules/babel-preset-es2015 ] ] -p bundle-collapser/plugin | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
-  },
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",

--- a/jspm/package.json
+++ b/jspm/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "scripts": {
     "postinstall": "jspm install",
-    "compile": "jspm build src/app.js ../src/dist/bundle.js --skip-source-maps --minify --format global --global-name app"
   },
   "dependencies": {
     "jspm": "^0.17.0-beta.6"

--- a/jspm/package.json
+++ b/jspm/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "postinstall": "jspm install",
+    "postinstall": "jspm install"
   },
   "dependencies": {
     "jspm": "^0.17.0-beta.6"

--- a/rollup-plugin-babel/package.json
+++ b/rollup-plugin-babel/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "rollup -c | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
-  },
   "dependencies": {
     "babel-preset-es2015-rollup": "^1.1.1",
     "rollup": "^0.25.2",

--- a/rollup/package.json
+++ b/rollup/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "rollup --format iife -- ../src/src/app.js | babel --presets ./node_modules/babel-preset-es2015 | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
-  },
   "dependencies": {
     "babel-cli": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",

--- a/traceur/package.json
+++ b/traceur/package.json
@@ -1,10 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "npm run traceur && npm run browserify",
-    "traceur": "traceur --modules=commonjs --dir ../src/src/ tmp/",
-    "browserify": "(cat node_modules/traceur/bin/traceur-runtime.js; browserify -p bundle-collapser/plugin tmp/app.js;) | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
-  },
   "dependencies": {
     "browserify": "^13.0.0",
     "bundle-collapser": "^1.2.1",

--- a/typescript-webpack/package.json
+++ b/typescript-webpack/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "tsc && webpack ./dist/app.js ../src/dist/bundle.js -p"
-  },
   "dependencies": {
     "typescript": "^1.8.0",
     "webpack": "^1.12.13"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "tsc && browserify -p bundle-collapser/plugin ./dist/*.js | uglifyjs --compress --mangle - > ../src/dist/bundle.js"
-  },
   "dependencies": {
     "browserify": "^13.0.0",
     "bundle-collapser": "^1.2.1",

--- a/webpack-2/package.json
+++ b/webpack-2/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "webpack ../src/src/app.js ../src/dist/bundle.js"
-  },
   "dependencies": {
     "babel-loader": "^6.2.2",
     "babel-preset-es2015-webpack": "^6.3.14",

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "compile": "webpack ../src/src/app.js ../src/dist/bundle.js"
-  },
   "dependencies": {
     "babel-loader": "^6.2.2",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
This change should…
- improve transparency: easier to see & compare the various build pipelines
- improve maintainability: easier to port & run the project to Windows

seem good?
