### PR TITLE
`make brotli`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ typescript/dist
 typescript-webpack/dist
 traceur/tmp
 jspm/jspm_packages
+brotli-0.3.0
+v0.3.0.tar.gz
 
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - time
+      - g++-4.8
 language: node_js
 node_js:
 - "5.0"
 env:
-  - chromeBinaryPath=/home/travis/build/samccone/drool/chrome-linux/chrome
+  - CXX=g++-4.8 chromeBinaryPath=/home/travis/build/samccone/drool/chrome-linux/chrome
 before_install:
+- make brotli
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - curl -Lo chrome.zip https://download-chromium.appspot.com/dl/Linux_x64 && unzip chrome.zip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: babel typescript closure rollup traceur size rollup-plugin-babel webpack babelify jspm webpack-2 typescript-webpack
+.PHONY: babel typescript closure rollup traceur size rollup-plugin-babel webpack babelify jspm webpack-2 typescript-webpack brotli
 
 # local binary paths
 browserify = node ./node_modules/browserify/bin/cmd.js
@@ -9,6 +9,7 @@ tsc = node node_modules/typescript/bin/tsc
 rollup = node node_modules/rollup/bin/rollup
 jspm = node node_modules/jspm/jspm.js
 webpack = node node_modules/webpack/bin/webpack.js
+bro = brotli-0.3.0/tools/bro
 
 all:
 	make typescript
@@ -77,9 +78,14 @@ typescript-webpack:
 	cd typescript-webpack; npm i;
 	cd typescript-webpack; time $(tsc) && $(webpack) ./dist/app.js ../src/dist/bundle.js -p
 
+brotli:
+	wget https://github.com/google/brotli/archive/v0.3.0.tar.gz
+	tar -xf v0.3.0.tar.gz
+	make -C brotli-0.3.0/tools/
+
 size:
 	@echo -----------------------------------------
 	cat src/dist/bundle.js | wc -c
 	gzip -c src/dist/bundle.js | wc -c
-	bro --input src/dist/bundle.js | wc -c
+	$(bro) --input src/dist/bundle.js | wc -c
 	@echo -----------------------------------------


### PR DESCRIPTION
Seems like like it's working.
https://travis-ci.org/MayhemYDG/The-cost-of-transpiling-es2015-in-2016/builds/108394408

The makefile should be improved to only fallback to compiling brotli if it doesn't exist on your machine already, but makefiles aren't my forte.
